### PR TITLE
adds circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    steps:
+    - checkout
+
+    - run: |
+        wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+        chmod +x ./architect
+        ./architect version
+    - run: ./architect build
+    - deploy:
+        command: |
+          if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            ./architect deploy
+          fi

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
+[![CircleCI](https://circleci.com/gh/giantswarm/e2etests.svg?&style=shield&circle-token=b073a6656900176b7e5d03d568a102b428c01afd)](https://circleci.com/gh/giantswarm/e2etests)
+
 # e2etests
-Package e2etests implements primitives for e2e tests against Giant Swarm Kubernetes guest clusters. 
+Package e2etests implements primitives for e2e tests against Giant Swarm
+Kubernetes guest clusters.

--- a/main.go
+++ b/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1918. The idea is to come up with a library that defines e2e tests we can run against each provider. Having one tests suite to cover the common functionality like guest cluster creation, deletion, scaling, updating, etc. will increase reliability of our service across platforms and ease QA in that regard because we only have to write a test once. In the next steps I will check on the interface for certain tests and how it could work out best to write and wire such tests. 