### PR TITLE
uses max wait for waiting for created status condition

### DIFF
--- a/update/update.go
+++ b/update/update.go
@@ -65,7 +65,7 @@ func (u *Update) Test(ctx context.Context) error {
 
 			return microerror.Mask(missesDesiredStatusError)
 		}
-		b := backoff.NewConstant(10*time.Minute, 2*time.Minute)
+		b := backoff.NewConstant(u.maxWait, 5*time.Minute)
 		n := backoff.NewNotifier(u.logger, ctx)
 
 		err := backoff.RetryNotify(o, b, n)


### PR DESCRIPTION
AWS seems to take quite long and with the newer versions in Azure it will be the same. Increasing the max wait for the creation phase as it is already done for the update phase. 