### PR TITLE
Make running release tests configurable

### DIFF
--- a/managedservices/managedservices.go
+++ b/managedservices/managedservices.go
@@ -143,14 +143,18 @@ func (ms *ManagedServices) Test(ctx context.Context) error {
 	}
 
 	{
-		ms.logger.LogCtx(ctx, "level", "debug", "message", "running release tests")
+		if ms.chartConfig.RunReleaseTests {
+			ms.logger.LogCtx(ctx, "level", "debug", "message", "running release tests")
 
-		err = ms.helmClient.RunReleaseTest(ms.chartConfig.ChartName)
-		if err != nil {
-			return microerror.Mask(err)
+			err = ms.helmClient.RunReleaseTest(ms.chartConfig.ChartName)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			ms.logger.LogCtx(ctx, "level", "debug", "message", "release tests passed")
+		} else {
+			ms.logger.LogCtx(ctx, "level", "debug", "message", "skipping release tests")
 		}
-
-		ms.logger.LogCtx(ctx, "level", "debug", "message", "release tests passed")
 	}
 
 	return nil

--- a/managedservices/spec.go
+++ b/managedservices/spec.go
@@ -68,7 +68,7 @@ type Interface interface {
 	// - Install chart.
 	// - Check chart is deployed.
 	// - Check key resources are correct.
-	// - Run helm release tests.
+	// - Run helm release tests if configured.
 	//
 	Test(ctx context.Context) error
 }

--- a/managedservices/spec.go
+++ b/managedservices/spec.go
@@ -8,10 +8,11 @@ import (
 
 // ChartConfig is the chart to test.
 type ChartConfig struct {
-	ChannelName string
-	ChartName   string
-	ChartValues string
-	Namespace   string
+	ChannelName     string
+	ChartName       string
+	ChartValues     string
+	Namespace       string
+	RunReleaseTests bool
 }
 
 func (cc ChartConfig) Validate() error {


### PR DESCRIPTION
Configures whether to run the helm release tests. Needed to prevent a nil pointer exception if there are no tests.