### PR TITLE
Make pod labels independent from deployment labels

### DIFF
--- a/managedservices/managedservices.go
+++ b/managedservices/managedservices.go
@@ -200,7 +200,7 @@ func (ms *ManagedServices) checkDeployment(expectedDeployment Deployment) error 
 		return microerror.Maskf(invalidReplicasError, "expected %d replicas got: %d", expectedDeployment.Replicas, *ds.Spec.Replicas)
 	}
 
-	err = ms.checkLabels("deployment labels", expectedDeployment.Labels, ds.ObjectMeta.Labels)
+	err = ms.checkLabels("deployment labels", expectedDeployment.DeploymentLabels, ds.ObjectMeta.Labels)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -210,7 +210,7 @@ func (ms *ManagedServices) checkDeployment(expectedDeployment Deployment) error 
 		return microerror.Mask(err)
 	}
 
-	err = ms.checkLabels("deployment pod labels", expectedDeployment.Labels, ds.Spec.Template.ObjectMeta.Labels)
+	err = ms.checkLabels("deployment pod labels", expectedDeployment.PodLabels, ds.Spec.Template.ObjectMeta.Labels)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/managedservices/spec.go
+++ b/managedservices/spec.go
@@ -54,11 +54,12 @@ type DaemonSet struct {
 
 // Deployment is a deployment to be tested.
 type Deployment struct {
-	Name        string
-	Namespace   string
-	Labels      map[string]string
-	MatchLabels map[string]string
-	Replicas    int
+	Name             string
+	Namespace        string
+	DeploymentLabels map[string]string
+	MatchLabels      map[string]string
+	PodLabels        map[string]string
+	Replicas         int
 }
 
 type Interface interface {


### PR DESCRIPTION
It doesn't make sense to me to ensure that pod labels = deployment labels. This PR is trying to fix the situation I hit in https://github.com/giantswarm/kubernetes-coredns/pull/21

slack thread: https://gigantic.slack.com/archives/C2MS2VB37/p1544805479037400