### PR TITLE
Nodes ready

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -197,8 +197,8 @@
   revision = "9922087c8f77cf4aff19bb8cf4c488a9dc4206f8"
 
 [[projects]]
-  branch = "master"
-  digest = "1:6131764fade79740526eaded582068ae1d858334f9d2c2a93cb389e311cad854"
+  branch = "nodesReady"
+  digest = "1:c7304b752d8400606f20a0fd5097ae4eb26f5b2bd4c13cd8de965c1930ff7d59"
   name = "github.com/giantswarm/e2e-harness"
   packages = [
     "internal/filelogger",
@@ -207,7 +207,7 @@
     "pkg/harness",
   ]
   pruneopts = "UT"
-  revision = "639b4bb14f3f8000c35681f3fb4dcb5d4a0c95a1"
+  revision = "1bddc65a2e3db47248c255251bd24ffc728e1a24"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -197,7 +197,7 @@
   revision = "9922087c8f77cf4aff19bb8cf4c488a9dc4206f8"
 
 [[projects]]
-  branch = "nodesReady"
+  branch = "master"
   digest = "1:c7304b752d8400606f20a0fd5097ae4eb26f5b2bd4c13cd8de965c1930ff7d59"
   name = "github.com/giantswarm/e2e-harness"
   packages = [

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -59,7 +59,7 @@ required = [
   name = "github.com/giantswarm/e2eclients"
 
 [[constraint]]
-  branch = "nodesReady"
+  branch = "master"
   name = "github.com/giantswarm/e2e-harness"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -59,7 +59,7 @@ required = [
   name = "github.com/giantswarm/e2eclients"
 
 [[constraint]]
-  branch = "master"
+  branch = "nodesReady"
   name = "github.com/giantswarm/e2e-harness"
 
 [[constraint]]

--- a/clusterstate/clusterstate.go
+++ b/clusterstate/clusterstate.go
@@ -99,7 +99,7 @@ func (c *ClusterState) Test(ctx context.Context) error {
 	{
 		c.logger.LogCtx(ctx, "level", "debug", "message", "waiting for guest cluster")
 
-		err = c.guestFramework.WaitForGuestReady()
+		err = c.guestFramework.WaitForGuestReady(ctx)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -143,7 +143,7 @@ func (c *ClusterState) Test(ctx context.Context) error {
 	{
 		c.logger.LogCtx(ctx, "level", "debug", "message", "waiting for guest cluster")
 
-		err = c.guestFramework.WaitForGuestReady()
+		err = c.guestFramework.WaitForGuestReady(ctx)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/scaling/provider/aws.go
+++ b/scaling/provider/aws.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/giantswarm/e2e-harness/pkg/framework"
@@ -122,8 +123,8 @@ func (a *AWS) RemoveWorker() error {
 	return nil
 }
 
-func (a *AWS) WaitForNodes(num int) error {
-	err := a.guestFramework.WaitForNodesUp(num)
+func (a *AWS) WaitForNodes(ctx context.Context, num int) error {
+	err := a.guestFramework.WaitForNodesReady(ctx, num)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/scaling/provider/azure.go
+++ b/scaling/provider/azure.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/giantswarm/e2e-harness/pkg/framework"
@@ -122,8 +123,8 @@ func (a *Azure) RemoveWorker() error {
 	return nil
 }
 
-func (a *Azure) WaitForNodes(num int) error {
-	err := a.guestFramework.WaitForNodesUp(num)
+func (a *Azure) WaitForNodes(ctx context.Context, num int) error {
+	err := a.guestFramework.WaitForNodesReady(ctx, num)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/scaling/provider/kvm.go
+++ b/scaling/provider/kvm.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/giantswarm/e2e-harness/pkg/framework"
@@ -122,8 +123,8 @@ func (k *KVM) RemoveWorker() error {
 	return nil
 }
 
-func (k *KVM) WaitForNodes(num int) error {
-	err := k.guestFramework.WaitForNodesUp(num)
+func (k *KVM) WaitForNodes(ctx context.Context, num int) error {
+	err := k.guestFramework.WaitForNodesReady(ctx, num)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/scaling/provider/spec.go
+++ b/scaling/provider/spec.go
@@ -1,11 +1,13 @@
 package provider
 
+import "context"
+
 type Interface interface {
 	AddWorker() error
 	NumMasters() (int, error)
 	NumWorkers() (int, error)
 	RemoveWorker() error
-	WaitForNodes(num int) error
+	WaitForNodes(ctx context.Context, num int) error
 }
 
 type Patch struct {

--- a/scaling/scaling.go
+++ b/scaling/scaling.go
@@ -77,7 +77,7 @@ func (s *Scaling) Test(ctx context.Context) error {
 	{
 		s.logger.LogCtx(ctx, "level", "debug", "message", "waiting for scaling up to be complete")
 
-		err = s.provider.WaitForNodes(numMasters + numWorkers + 1)
+		err = s.provider.WaitForNodes(ctx, numMasters+numWorkers+1)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -99,7 +99,7 @@ func (s *Scaling) Test(ctx context.Context) error {
 	{
 		s.logger.LogCtx(ctx, "level", "debug", "message", "waiting for scaling down to be complete")
 
-		err = s.provider.WaitForNodes(numMasters + numWorkers)
+		err = s.provider.WaitForNodes(ctx, numMasters+numWorkers)
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
Towards: giantswarm/giantswarm#4692

Follow-up on https://github.com/giantswarm/e2e-harness/pull/181

vendor new e2e-harness with `WaitForNodesReady`