### PR TITLE
set instance type to m4.xlarge in e2e tests

### DIFF
--- a/clusterstate/provider/aws.go
+++ b/clusterstate/provider/aws.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	EC2InstanceType = "m5.xlarge"
+	EC2InstanceType = "m4.xlarge"
 )
 
 type AWSConfig struct {


### PR DESCRIPTION
This should be aligned with production. 