### PR TITLE
drop e2e-harness from KVM update test

### DIFF
--- a/update/provider/spec.go
+++ b/update/provider/spec.go
@@ -1,6 +1,15 @@
 package provider
 
-import "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+)
+
+type Clients interface {
+	// G8sClient returns a properly configured control plane client for the Giant
+	// Swarm API Extensions Types.
+	G8sClient() versioned.Interface
+}
 
 type Interface interface {
 	CurrentStatus() (v1alpha1.StatusCluster, error)


### PR DESCRIPTION
Some efforts to drop `e2e-harness` where possible. 