### PR TITLE
Check used AZs as part of cluster state test

### DIFF
--- a/clusterstate/clusterstate.go
+++ b/clusterstate/clusterstate.go
@@ -52,6 +52,28 @@ func (c *ClusterState) Test(ctx context.Context) error {
 	var err error
 
 	{
+		c.logger.LogCtx(ctx, "level", "debug", "message", "getting current AZs in tenant cluster")
+		zones, err := c.provider.GetClusterAZs(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		c.logger.LogCtx(ctx, "level", "debug", "message", "found AZs in tenant cluster", "azs", zones)
+
+		c.logger.LogCtx(ctx, "level", "debug", "message", "getting expected AZs from CR")
+		expectedAZs, err := c.provider.ExpectedAZs()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		c.logger.LogCtx(ctx, "level", "debug", "message", "found expected AZs from CR", "azs", expectedAZs)
+
+		for i, v := range expectedAZs {
+			if v != zones[i] {
+				return microerror.Maskf(executionFailedError, "Expected %v zones, got %v zones", expectedAZs, zones)
+			}
+		}
+	}
+
+	{
 		c.logger.LogCtx(ctx, "level", "debug", "message", "installing e2e-app")
 
 		err = c.InstallTestApp(ctx)

--- a/clusterstate/error.go
+++ b/clusterstate/error.go
@@ -28,3 +28,7 @@ var waitError = &microerror.Error{
 func IsWait(err error) bool {
 	return microerror.Cause(err) == waitError
 }
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}

--- a/clusterstate/provider/spec.go
+++ b/clusterstate/provider/spec.go
@@ -1,6 +1,10 @@
 package provider
 
-import "k8s.io/client-go/kubernetes"
+import (
+	"context"
+
+	"k8s.io/client-go/kubernetes"
+)
 
 type Clients interface {
 	// K8sClient returns a properly configured control plane client for the
@@ -11,4 +15,6 @@ type Clients interface {
 type Interface interface {
 	RebootMaster() error
 	ReplaceMaster() error
+	GetClusterAZs(ctx context.Context) ([]string, error)
+	ExpectedAZs() ([]string, error)
 }


### PR DESCRIPTION
We added a new test that checks the availability zones being used. Instead of running a new test, I thought it could be a good idea to add that assertion to the `ClusterState` test that's already there. The provider implementation needs to implement the required methods.