### PR TITLE
Added e2e test that creates pvc

### DIFF
--- a/clusterstate/clusterstate.go
+++ b/clusterstate/clusterstate.go
@@ -11,7 +11,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -271,22 +271,22 @@ func (c *ClusterState) CheckTestAppIsInstalled(ctx context.Context) error {
 
 func (c *ClusterState) CreatePVC(ctx context.Context) error {
 	pvcName := "e2e-pvc"
-	pvc := &v1.PersistentVolumeClaim{
+	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pvcName,
 			Namespace: "default",
 		},
-		Spec: v1.PersistentVolumeClaimSpec{
-			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-			Resources: v1.ResourceRequirements{
-				Requests: v1.ResourceList{
-					v1.ResourceName(v1.ResourceStorage): resource.MustParse("1Gi"),
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("1Gi"),
 				},
 			},
 		},
 	}
 
-	c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating pvc '%s'", pvcName))
+	c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating pvc %#q", pvcName))
 	_, err := c.legacyFramework.K8sClient().CoreV1().PersistentVolumeClaims("default").Create(pvc)
 	if err != nil {
 		return microerror.Mask(err)
@@ -298,7 +298,7 @@ func (c *ClusterState) CreatePVC(ctx context.Context) error {
 			return microerror.Mask(err)
 		}
 
-		if pvc.Status.Phase != v1.ClaimBound {
+		if pvc.Status.Phase != corev1.ClaimBound {
 			return microerror.Maskf(waitError, "PVC '%s' is not bound yet", pvcName)
 		}
 

--- a/clusterstate/clusterstate.go
+++ b/clusterstate/clusterstate.go
@@ -11,6 +11,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/afero"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/e2etests/clusterstate/provider"
@@ -161,6 +163,17 @@ func (c *ClusterState) Test(ctx context.Context) error {
 		c.logger.LogCtx(ctx, "level", "debug", "message", "test app is installed")
 	}
 
+	{
+		c.logger.LogCtx(ctx, "level", "debug", "message", "test if PVC is bound")
+
+		err = c.CreatePVC(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		c.logger.LogCtx(ctx, "level", "debug", "message", "tested if PVC is bound")
+	}
+
 	return nil
 }
 
@@ -252,6 +265,55 @@ func (c *ClusterState) CheckTestAppIsInstalled(ctx context.Context) error {
 	}
 
 	c.logger.Log("level", "debug", "message", fmt.Sprintf("found %d pods of the e2e-app", podCount))
+
+	return nil
+}
+
+func (c *ClusterState) CreatePVC(ctx context.Context) error {
+	pvcName := "e2e-pvc"
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: "default",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating pvc '%s'", pvcName))
+	_, err := c.legacyFramework.K8sClient().CoreV1().PersistentVolumeClaims("default").Create(pvc)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	o := func() error {
+		pvc, err := c.legacyFramework.K8sClient().CoreV1().PersistentVolumeClaims("default").Get(pvcName, metav1.GetOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if pvc.Status.Phase != v1.ClaimBound {
+			return microerror.Maskf(waitError, "PVC '%s' is not bound yet", pvcName)
+		}
+
+		return nil
+	}
+
+	b := backoff.NewConstant(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+	n := func(err error, delay time.Duration) {
+		c.logger.Log("level", "debug", "message", err.Error())
+	}
+
+	err = backoff.RetryNotify(o, b, n)
+	if err != nil {
+		return microerror.Mask(err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
When preparing a new release, we were manually testing that PVC's can be created and bound. It could be a good idea to automate it.
I think this should work across all providers, but I'm not sure about KVM.

[Testing it here](https://github.com/giantswarm/azure-operator/pull/652) for azure-operator.

EDIT: Test passed https://circleci.com/gh/giantswarm/azure-operator/7327