### PR TITLE
Remove validation of resources in basicapp test as its too restrictive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove validation of resources in basicapp test as its too restrictive.
+
 ## [0.2.0] 2020-03-26
 
 ### Changed
-- switch from dep to go modules
-- use architect-orb
+
+- Switch from dep to go modules.
+- Use architect-orb.
 
 ## [0.1.0] 2020-03-19
 

--- a/basicapp/basicapp.go
+++ b/basicapp/basicapp.go
@@ -52,10 +52,6 @@ func New(config Config) (*BasicApp, error) {
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-	err = config.ChartResources.Validate()
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
 
 	var resource *legacyresource.Resource
 	{

--- a/basicapp/spec.go
+++ b/basicapp/spec.go
@@ -43,14 +43,6 @@ type ChartResources struct {
 	Services    []Service
 }
 
-func (cr ChartResources) Validate() error {
-	if len(cr.DaemonSets) == 0 && len(cr.Deployments) == 0 && len(cr.Services) == 0 {
-		return microerror.Maskf(invalidConfigError, "at least one daemonset, deployment or service must be specified")
-	}
-
-	return nil
-}
-
 // DaemonSet is a daemonset to be tested.
 type DaemonSet struct {
 	Name        string


### PR DESCRIPTION
Prep for https://github.com/giantswarm/gatekeeper-control-plane-rules/pull/22.

I want to use the basicapp test but since it only creates CRDs and CRs this validation does not make sense.


## Checklist

- [x] Update changelog in CHANGELOG.md.
