### PR TITLE
Check the right deployed status

### DIFF
--- a/basicapp/basicapp.go
+++ b/basicapp/basicapp.go
@@ -97,7 +97,7 @@ func (b *BasicApp) Test(ctx context.Context) error {
 	{
 		b.logger.LogCtx(ctx, "level", "debug", "message", "waiting for deployed status")
 
-		err = b.resource.WaitForStatus(b.chart.Name, "DEPLOYED")
+		err = b.resource.WaitForStatus(b.chart.Name, "deployed")
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
```
{"caller":"github.com/giantswarm/e2etests/basicapp/legacyresource/resource.go:176","level":"debug","message":"failed to get release status 'DEPLOYED': retrying in 51.652285011s","stack":"release status not matching error: waiting for 'DEPLOYED', current 'deployed'","time":"2020-05-20T12:32:48.360357+00:00"}
{"caller":"github.com/giantswarm/e2etests/basicapp/legacyresource/resource.go:176","level":"debug","message":"failed to get release status 'DEPLOYED': retrying in 1m4.240396564s","stack":"release status not matching error: waiting for 'DEPLOYED', current 'deployed'","time":"2020-05-20T12:33:40.038139+00:00"}
{"caller":"github.com/giantswarm/e2etests/basicapp/legacyresource/resource.go:176","level":"debug","message":"failed to get release status 'DEPLOYED': retrying in 1m21.749486247s","stack":"release status not matching error: waiting for 'DEPLOYED', current 'deployed'","time":"2020-05-20T12:34:44.303024+00:00"}
--- FAIL: TestHelm (686.14s)
    basic_test.go:15: {"kind":"releaseStatusNotMatchingError","annotation":"waiting for 'DEPLOYED', current 'deployed'","stack":[{"file":"/home/circleci/.go_workspace/pkg/mod/github.com/giantswarm/e2etests@v0.3.0/basicapp/legacyresource/resource.go","line":170},{"file":"/home/circleci/.go_workspace/pkg/mod/github.com/giantswarm/backoff@v0.2.0/retry.go","line":23},{"file":"/home/circleci/.go_workspace/pkg/mod/github.com/giantswarm/e2etests@v0.3.0/basicapp/legacyresource/resource.go","line":182},{"file":"/home/circleci/.go_workspace/pkg/mod/github.com/giantswarm/e2etests@v0.3.0/basicapp/basicapp.go","line":102}]}
FAIL
FAIL	github.com/giantswarm/cert-manager-app/integration/test/basic	686.432s
FAIL
```

Another `DEPLOYED` vs. `deployed`